### PR TITLE
fix: reverse the enumeration of the Luhn algorithm

### DIFF
--- a/sanatio/utils/checksum.py
+++ b/sanatio/utils/checksum.py
@@ -86,7 +86,7 @@ class LuhnAlgorithm(BaseChecksumAlgorithm):
         last_digit, remaining_numbers = self.last_digit_and_remaining_numbers()
         nums = [int(num) if idx % 2 != 0 else int(num) * 2 if int(num) * 2 <= 9
                 else int(num) * 2 % 10 + int(num) * 2 // 10
-                for idx, num in enumerate(remaining_numbers)]
+                for idx, num in enumerate(reversed(remaining_numbers))]
 
         return (sum(nums) + last_digit) % 10 == 0
 

--- a/tests/checksum_algorithms/checksum_algo_test.py
+++ b/tests/checksum_algorithms/checksum_algo_test.py
@@ -15,5 +15,9 @@ class CheckSumTest(unittest.TestCase):
         luhn = LuhnAlgorithm('4569403961014710')
         self.assertTrue(luhn.verify())
         
+    def test_luhn_short_True(self):
+        luhn = LuhnAlgorithm('109')
+        self.assertTrue(luhn.verify())
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/document/credit_card_test.py
+++ b/tests/document/credit_card_test.py
@@ -13,7 +13,7 @@ class CreditCardTest(unittest.TestCase):
         self.assertTrue(validator.isCreditCard('6011000990139424'))
         
     def test_credit_card_false(self):
-        self.assertFalse(validator.isCreditCard('370341378581367'))   # checksome false
+        self.assertFalse(validator.isCreditCard('370341378581368'))   # checksome false
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverses the enumeration as specified in issue #10. Two additional notes:
- The original code requires `python-dateutil` to run the tests, but which is not specified in `requirements.txt`. `python-dateutil==2.9.0` worked fine for me.
- I actually found this repo through Wikipedia (https://en.wikipedia.org/wiki/Luhn_algorithm). If you added the code, you might want to change the snippet there too.